### PR TITLE
values passed as concrete instance, not types

### DIFF
--- a/examples/enforced_parameters.py
+++ b/examples/enforced_parameters.py
@@ -33,6 +33,6 @@ container = Container()
 
 # view layer handling
 
-controller = container.resolve(Controller, domain_model=ConcreteDomainModel)
+controller = container.resolve(Controller, domain_model=ConcreteDomainModel())
 result = controller.handler(1)
 print(result)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("readme.md", "r") as fh:
 
 setup(
     name="inseminator",
-    version="0.1",
+    version="0.2",
     description="Python dependency injection library based on type hints",
     author="Milan Suk",
     author_email="Milansuk@email.com",

--- a/src/resolver.py
+++ b/src/resolver.py
@@ -14,7 +14,7 @@ class DependencyResolver:
     def __init__(self, container: ScopedDict[Dependable, Dependency]) -> None:
         self._container = container
 
-    def resolve(self, dependency: Dependable, parameters: Optional[Dict[str, Dependable]] = None) -> Dependency[T]:
+    def resolve(self, dependency: Dependable, parameters: Optional[Dict[str, Any]] = None) -> Dependency[T]:
         if dependency in self._container:
             return self._container[dependency]
 
@@ -31,11 +31,11 @@ class DependencyResolver:
         if parameters:
             parameter_names = type_hints.keys()
 
-            for parameter_name, parameter_dependency in parameters.items():
+            for parameter_name, parameter_value in parameters.items():
                 if parameter_name not in parameter_names:
                     raise ResolverError(f"Parameter {parameter_name} it not part of {dependency.__name__}'s signature.")
 
-                args[parameter_name] = self.resolve(parameter_dependency).get_instance()
+                args[parameter_name] = parameter_value
 
         for parameter_name, parameter_dependency in type_hints.items():
             if parameter_name == "return" or parameter_name in args:


### PR DESCRIPTION
`container.resolve(MyType, parameter_1=1)` will now pass `1` as the parameter `parameter_1` instead of trying to resolve the parameter by resolver again. So instead of

```
container.resolve(MyType, dependency_parameter=DependencyClass)
```

one will use

```
dependency = container.resolve(DependencyClass)
container.resolve(MyType, depedency_parameter=depedency)
```